### PR TITLE
Make composer.json validate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "guzzle/silex-provider",
-    "type": "silex provider",
+    "type": "silex-provider",
     "description": "Guzzle silex provider",
     "keywords": ["Guzzle", "Silex"],
     "version": "2.0",


### PR DESCRIPTION
This un-breaks it on packagist, so that new versions get parsed again.

Note: that type is not defined anywhere so it may be defined differently in the future, or not defined at all.
