### PR TITLE
Add branch-alias to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,10 @@
     },
     "autoload": {
         "classmap": [ "GuzzleServiceProvider.php" ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows requiring version ~1.0@dev instead of dev-master.

Please tag v1.0.0 soon.
